### PR TITLE
Provided context for text completion

### DIFF
--- a/k8s/llama-2-7b.yaml
+++ b/k8s/llama-2-7b.yaml
@@ -13,9 +13,25 @@ spec:
         app: llama
     spec:
       containers:
-      - name: llama-container
+      - command:
+        - /bin/sh
+        - -c
+        - cd /workspace/llama/llama-2-7b && torchrun web_example_text_completion.py
+        name: llama-container
         image: ishaansehgal99/llama-2-7b:latest
-
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+          requests:
+            nvidia.com/gpu: "1"
+      tolerations:
+      - effect: NoSchedule
+        key: sku
+        operator: Equal
+        value: gpu
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
 ---
 
 apiVersion: v1
@@ -30,4 +46,3 @@ spec:
       port: 80
       targetPort: 5000
   type: LoadBalancer
-

--- a/k8s/pod.yaml
+++ b/k8s/pod.yaml
@@ -9,7 +9,7 @@ spec:
   - command:
     - sleep
     - infinity
-    image: ishaansehgal99/llama-2-7b:latest
+    image: ishaansehgal99/llama-2-7b-chat:latest
     name: main
     resources:
       limits:

--- a/llama-2-7b-chat/Dockerfile
+++ b/llama-2-7b-chat/Dockerfile
@@ -6,14 +6,6 @@ RUN git clone https://github.com/facebookresearch/llama
 WORKDIR /workspace/llama
 
 RUN pip install -e .
+RUN pip install flask
 
 ADD code /workspace/llama/llama-2-7b-chat
-COPY code/tokenizer.model /workspace/llama/tokenizer.model
-COPY code/example_chat_completion.py /workspace/llama/example_chat_completion.py
-
-ADD code/weights /workspace/llama/llama-2-7b-chat/weights
-COPY code/weights/consolidated.00.pth /workspace/llama/llama-2-7b-chat/weights/consolidated.00.pth
-COPY code/weights/params.json /workspace/llama/llama-2-7b-chat/weights/params.json
-COPY code/weights/checklist.chk /workspace/llama/llama-2-7b-chat/weights/checklist.chk
-
-CMD ["torchrun", "/workspace/llama/web_example_chat_completion.py"]

--- a/llama-2-7b-chat/code/web_example_chat_completion.py
+++ b/llama-2-7b-chat/code/web_example_chat_completion.py
@@ -4,29 +4,6 @@ import os
 
 app = Flask(__name__)
 
-class SlidingWindow:
-    def __init__(self, max_seq_len):
-        self.max_seq_len = max_seq_len
-        self.token_history = []
-
-    def append(self, max_gen_len, new_prompt_tokens):
-        available_tokens = self.max_seq_len - len(new_prompt_tokens)
-        if available_tokens < 0:
-            return None
-
-        # Account for tokens required for model output
-        available_tokens -= max_gen_len
-
-        if available_tokens > len(self.token_history):
-            self.token_history.extend(new_prompt_tokens)
-            return self.token_history
-
-        # If the total tokens exceed the allowed limit, remove the earliest tokens
-        global generator
-        self.token_history = self.token_history[-available_tokens:] + new_prompt_tokens
-        assert len(self.token_history) == self.max_seq_len - max_gen_len
-        return self.token_history
-
 # Default values for the generator
 gen_params = {
     'ckpt_dir': 'weights/',
@@ -43,8 +20,6 @@ generator = Llama.build(
     max_batch_size=gen_params['max_batch_size'],
 )
 
-window = SlidingWindow(max_seq_len=gen_params['max_seq_len'])
-
 @app.route('/')
 def health_check():
     return "Server is running", 200
@@ -53,12 +28,7 @@ def health_check():
 def configure_generator():
     global generator
     global gen_params
-    global window
 
-    context = request.json.get('context')
-    if context and context.strip().lower() == "clear":
-        window.token_history.clear()
-    
     new_params = {}
     for key, value in gen_params.items():
         new_params[key] = request.json.get(key, value)
@@ -76,45 +46,33 @@ def configure_generator():
     except Exception as e: 
         return jsonify(error="Failed invalid parameters: " + str(e)), 400
 
-    window.max_seq_len = gen_params['max_seq_len']
     return jsonify(status="success"), 200
 
-@app.route('/chat', methods=['GET'])
+@app.route('/chat', methods=['POST'])
 def chat_completion():
-    role = request.args.get('role')
-    prompt = request.args.get('prompt')
+    data = request.json
+    input_data = data.get('input_data')
+    if not input_data:
+        return jsonify(error="Input data is required"), 400
+    
+    input_string = input_data.get("input_string")
+    if not input_data:
+        return jsonify(error="Input string is required"), 400
 
-    # Check if the role and prompt are provided
-    if not role or not prompt:
-        return jsonify(error="Role and Prompt are required"), 400
-
-    temperature = float(request.args.get('temperature', 0.6))
-    top_p = float(request.args.get('top_p', 0.9))
-    max_gen_len = int(request.args.get('max_gen_len', 64))
-    context = request.args.get('context')
-    if context and context.strip().lower() == "true":
-        # Tokenize the prompt using the tokenizer
-        tokenizer = generator.tokenizer
-        new_prompt_tokens = tokenizer.encode(prompt, bos=False, eos=False)
-
-        # Append new prompt to sliding window
-        result_window = window.append(max_gen_len, new_prompt_tokens)
-        if not result_window:
-            return jsonify(error="User input exceeds the maximum token length"), 400
-
-        # Decode resulting window
-        prompt = tokenizer.decode(result_window)
-        # print(prompt, "prompt with context")
+    parameters = data.get("parameters", {})
+    temperature = parameters.get('temperature', 0.6)
+    top_p = parameters.get('top_p', 0.9)
+    max_gen_len = parameters.get('max_gen_len', 64)
 
     try:
         results = generator.chat_completion(
-            [[{"role": role, "content": prompt}]], # type: ignore
+            [input_string],
             max_gen_len=max_gen_len,
             temperature=temperature,
             top_p=top_p,
         )
     except Exception as e:
-        return jsonify(error="Request Failed" + str(e)), 400
+        return jsonify(error="Request Failed: " + str(e)), 400
 
     if len(results) == 0:
         return jsonify(error="No results"), 404

--- a/llama-2-7b-chat/code/web_example_chat_completion.py
+++ b/llama-2-7b-chat/code/web_example_chat_completion.py
@@ -1,23 +1,83 @@
 from flask import Flask, request, jsonify
 from llama import Llama
-from typing import Optional
+import os
 
 app = Flask(__name__)
 
+class SlidingWindow:
+    def __init__(self, max_seq_len):
+        self.max_seq_len = max_seq_len
+        self.token_history = []
+
+    def append(self, max_gen_len, new_prompt_tokens):
+        available_tokens = self.max_seq_len - len(new_prompt_tokens)
+        if available_tokens < 0:
+            return None
+
+        # Account for tokens required for model output
+        available_tokens -= max_gen_len
+
+        if available_tokens > len(self.token_history):
+            self.token_history.extend(new_prompt_tokens)
+            return self.token_history
+
+        # If the total tokens exceed the allowed limit, remove the earliest tokens
+        global generator
+        self.token_history = self.token_history[-available_tokens:] + new_prompt_tokens
+        assert len(self.token_history) == self.max_seq_len - max_gen_len
+        return self.token_history
+
 # Default values for the generator
-default_values = {
+gen_params = {
     'ckpt_dir': 'weights/',
     'tokenizer_path': 'tokenizer.model',
-    'max_seq_len': 512,
-    'max_batch_size': 4
+    'max_seq_len': 128,
+    'max_batch_size': 4,
+    'model_parallel_size': int(os.environ.get("WORLD_SIZE", 1)),
 }
 
 generator = Llama.build(
-    ckpt_dir=default_values['ckpt_dir'],
-    tokenizer_path=default_values['tokenizer_path'],
-    max_seq_len=default_values['max_seq_len'],
-    max_batch_size=default_values['max_batch_size']
+    ckpt_dir=gen_params['ckpt_dir'],
+    tokenizer_path=gen_params['tokenizer_path'],
+    max_seq_len=gen_params['max_seq_len'],
+    max_batch_size=gen_params['max_batch_size'],
 )
+
+window = SlidingWindow(max_seq_len=gen_params['max_seq_len'])
+
+@app.route('/')
+def health_check():
+    return "Server is running", 200
+
+@app.route('/configure', methods=['POST'])
+def configure_generator():
+    global generator
+    global gen_params
+    global window
+
+    context = request.json.get('context')
+    if context and context.strip().lower() == "clear":
+        window.token_history.clear()
+    
+    new_params = {}
+    for key, value in gen_params.items():
+        new_params[key] = request.json.get(key, value)
+
+    try:
+        generator = Llama.build(
+            ckpt_dir=new_params['ckpt_dir'],
+            tokenizer_path=new_params['tokenizer_path'],
+            max_seq_len=new_params['max_seq_len'],
+            max_batch_size=new_params['max_batch_size'],
+            # Reinitializing generator requires this additional param
+            model_parallel_size=new_params['model_parallel_size']
+        )
+        gen_params = new_params
+    except Exception as e: 
+        return jsonify(error="Failed invalid parameters: " + str(e)), 400
+
+    window.max_seq_len = gen_params['max_seq_len']
+    return jsonify(status="success"), 200
 
 @app.route('/chat', methods=['GET'])
 def chat_completion():
@@ -30,15 +90,31 @@ def chat_completion():
 
     temperature = float(request.args.get('temperature', 0.6))
     top_p = float(request.args.get('top_p', 0.9))
-    max_gen_len = request.args.get('max_gen_len')
-    max_gen_len = int(max_gen_len) if max_gen_len else None
+    max_gen_len = int(request.args.get('max_gen_len', 64))
+    context = request.args.get('context')
+    if context and context.strip().lower() == "true":
+        # Tokenize the prompt using the tokenizer
+        tokenizer = generator.tokenizer
+        new_prompt_tokens = tokenizer.encode(prompt, bos=False, eos=False)
 
-    results = generator.chat_completion(
-        [[{"role": role, "content": prompt}]], # type: ignore
-        max_gen_len=max_gen_len,
-        temperature=temperature,
-        top_p=top_p,
-    )
+        # Append new prompt to sliding window
+        result_window = window.append(max_gen_len, new_prompt_tokens)
+        if not result_window:
+            return jsonify(error="User input exceeds the maximum token length"), 400
+
+        # Decode resulting window
+        prompt = tokenizer.decode(result_window)
+        # print(prompt, "prompt with context")
+
+    try:
+        results = generator.chat_completion(
+            [[{"role": role, "content": prompt}]], # type: ignore
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+        )
+    except Exception as e:
+        return jsonify(error="Request Failed" + str(e)), 400
 
     if len(results) == 0:
         return jsonify(error="No results"), 404
@@ -48,24 +124,6 @@ def chat_completion():
         role=result['generation']['role'].capitalize(),
         content=result['generation']['content']
     )
-
-@app.route('/configure', methods=['POST'])
-def configure_generator():
-    global generator
-
-    ckpt_dir = request.json.get('ckpt_dir', default_values['ckpt_dir'])
-    tokenizer_path = request.json.get('tokenizer_path', default_values['tokenizer_path'])
-    max_seq_len = int(request.json.get('max_seq_len', default_values['max_seq_len']))
-    max_batch_size = int(request.json.get('max_batch_size', default_values['max_batch_size']))
-
-    generator = Llama.build(
-        ckpt_dir=ckpt_dir,
-        tokenizer_path=tokenizer_path,
-        max_seq_len=max_seq_len,
-        max_batch_size=max_batch_size,
-    )
-
-    return jsonify(status="success"), 200
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000)

--- a/llama-2-7b/Dockerfile
+++ b/llama-2-7b/Dockerfile
@@ -9,13 +9,3 @@ RUN pip install -e .
 RUN pip install flask
 
 ADD code /workspace/llama/llama-2-7b
-COPY code/tokenizer.model /workspace/llama/tokenizer.model
-COPY code/example_text_completion.py /workspace/llama/example_text_completion.py
-COPY code/web_example_text_completion.py /workspace/llama/web_example_text_completion.py
-
-ADD code/weights /workspace/llama/llama-2-7b/weights
-COPY code/weights/consolidated.00.pth /workspace/llama/llama-2-7b/weights/consolidated.00.pth
-COPY code/weights/params.json /workspace/llama/llama-2-7b/weights/params.json
-COPY code/weights/checklist.chk /workspace/llama/llama-2-7b/weights/checklist.chk
-
-CMD ["torchrun", "/workspace/llama/web_example_text_completion.py"]

--- a/llama-2-7b/code/web_example_text_completion.py
+++ b/llama-2-7b/code/web_example_text_completion.py
@@ -45,6 +45,10 @@ generator = Llama.build(
 
 window = SlidingWindow(max_seq_len=gen_params['max_seq_len'])
 
+@app.route('/')
+def health_check():
+    return "Server is running", 200
+
 @app.route('/configure', methods=['POST'])
 def configure_generator():
     global generator

--- a/llama-2-7b/code/web_example_text_completion.py
+++ b/llama-2-7b/code/web_example_text_completion.py
@@ -1,68 +1,67 @@
 from flask import Flask, request, jsonify
 from llama import Llama
-# from llama.tokenizer import Tokenizer
+import os
 
 app = Flask(__name__)
 
-class SlidingWindow: 
-    def __init__(self, max_seq_len, max_gen_len): 
+class SlidingWindow:
+    def __init__(self, max_seq_len):
         self.max_seq_len = max_seq_len
-        self.max_gen_len = max_gen_len
         self.token_history = []
 
-    def append(self, new_prompt_tokens): 
+    def append(self, max_gen_len, new_prompt_tokens):
         available_tokens = self.max_seq_len - len(new_prompt_tokens)
-        if available_tokens < 0: 
+        if available_tokens < 0:
             print("User input exceeds the maximum token length")
-        
+
         # Account for tokens required for model output
-        available_tokens -= self.max_gen_len
+        available_tokens -= max_gen_len
 
         if available_tokens > len(self.token_history):
             self.token_history.extend(new_prompt_tokens)
             return self.token_history
-                
+
         # If the total tokens exceed the allowed limit, remove the earliest tokens
         global generator
-        print(generator.tokenizer.decode(self.token_history[-available_tokens:]), "context")
         self.token_history = self.token_history[-available_tokens:] + new_prompt_tokens
-        assert len(self.token_history) == available_tokens
+        assert len(self.token_history) == self.max_seq_len - max_gen_len
         return self.token_history
 
 # Default values for the generator
-default_values = {
+gen_params = {
     'ckpt_dir': 'weights/',
     'tokenizer_path': 'tokenizer.model',
     'max_seq_len': 128,
-    'max_batch_size': 4
+    'max_batch_size': 4,
+    'model_parallel_size': int(os.environ.get("WORLD_SIZE", 1)),
 }
 
 generator = Llama.build(
-    ckpt_dir=default_values['ckpt_dir'],
-    tokenizer_path=default_values['tokenizer_path'],
-    max_seq_len=default_values['max_seq_len'],
-    max_batch_size=default_values['max_batch_size']
+    ckpt_dir=gen_params['ckpt_dir'],
+    tokenizer_path=gen_params['tokenizer_path'],
+    max_seq_len=gen_params['max_seq_len'],
+    max_batch_size=gen_params['max_batch_size'],
 )
 
-window = SlidingWindow(max_seq_len=default_values['max_seq_len'])
+window = SlidingWindow(max_seq_len=gen_params['max_seq_len'])
 
 @app.route('/configure', methods=['POST'])
 def configure_generator():
     global generator
 
-    ckpt_dir = request.json.get('ckpt_dir', default_values['ckpt_dir'])
-    tokenizer_path = request.json.get('tokenizer_path', default_values['tokenizer_path'])
-    max_seq_len = int(request.json.get('max_seq_len', default_values['max_seq_len']))
-    max_batch_size = int(request.json.get('max_batch_size', default_values['max_batch_size']))
+    for key, value in gen_params.items():
+        gen_params[key] = request.json.get(key, value)
 
     generator = Llama.build(
-        ckpt_dir=ckpt_dir,
-        tokenizer_path=tokenizer_path,
-        max_seq_len=max_seq_len,
-        max_batch_size=max_batch_size,
+        ckpt_dir=gen_params['ckpt_dir'],
+        tokenizer_path=gen_params['tokenizer_path'],
+        max_seq_len=gen_params['max_seq_len'],
+        max_batch_size=gen_params['max_batch_size'],
+        # Reinitializing generator requires this additional param
+        model_parallel_size=gen_params['model_parallel_size']
     )
 
-    window.max_seq_len = max_seq_len
+    window.max_seq_len = gen_params['max_seq_len']
     return jsonify(status="success"), 200
 
 @app.route('/generate', methods=['GET'])
@@ -75,22 +74,21 @@ def generate_text():
     temperature = float(request.args.get('temperature', 0.6))
     top_p = float(request.args.get('top_p', 0.9))
     max_gen_len = int(request.args.get('max_gen_len', 64))
+    context = request.args.get('context')
+    if context and context.strip().lower() == "true":
+        # Tokenize the prompt using the tokenizer
+        tokenizer = generator.tokenizer
+        new_prompt_tokens = tokenizer.encode(prompt, bos=False, eos=False)
 
-    # Tokenize the prompt using the tokenizer 
-    tokenizer = generator.tokenizer
-    new_prompt_tokens = tokenizer.encode(prompt, bos=False, eos=False)
+        # Append new prompt to sliding window
+        result_window = window.append(max_gen_len, new_prompt_tokens)
 
-    # Append to sliding window
-    result_window = window.append(new_prompt_tokens)
-
-    # Concatenate the prompt history
-    prompt_with_context = tokenizer.decode(result_window)
-
-    print(prompt, "prompt")
-    print(prompt_with_context, "prompt with context")
+        # Decode resulting window
+        prompt = tokenizer.decode(result_window)
+        # print(prompt, "prompt with context")
 
     results = generator.text_completion(
-        [prompt_with_context], # Note we pass context in the same prompt
+        [prompt], # Note when we pass context its in the same prompt
         max_gen_len=max_gen_len,
         temperature=temperature,
         top_p=top_p,

--- a/llama.md
+++ b/llama.md
@@ -1,5 +1,12 @@
 What makes llama 2 unique from traditional transformer based architecture? 
 
+-> System, Assistant, and User roles in chat, llama 2 chat model allows users to specify three roles.
+ - System role: The system role is used to indicate system messages. These messages are used to provide instructions to the model or tell the model about its environment. For example, the system role can be used to tell the model that it should be kind and helpful. 
+
+ - Assistant role: The assistant role is the role of the model. We can enter the assistant role to help guide the model further on how it should do its job or provide example expected answers to prompts.
+
+ - User role: The user role is used to indicate user input. This is the role that is used most often, as it is the role that the user is actually interacting with.
+
 -> Increased context length, context window for llama 2 model is doubled in size from 2048 to 4096 tokens. This allows model to process more information and better understand long sequences of text. 
 
 -> Grouped Query Attention (GQA) Llama 2 model uses GQA to improve effciency of the attention mechanism (attention is the most time consuming part of transformer arch). GQA groups similiar tokens together and attends to them as a single unit (uses the same Key, Query, Value) for them. This reduces number of computations that need to be performed which makes the model faster and more efficient. 


### PR DESCRIPTION
This PR introduces a context option for llama requests. It does this by caching previous requests that had context set to true. And in a sliding window fashion can include previous requests with context. 

Here is an example of using context:
```
k exec -it demo -- curl "http://127.0.0.1:5000/generate?prompt=Ishaan%20Works%20at%microsoft&c
ontext=true" 
```
Context: ""
Prompt: Ishaan works at Microsoft  
Prompt with context: Ishaan works at Microsoft

```
k exec -it demo -- curl "http://127.0.0.1:5000/generate?prompt=where%20does%20%Ishaan%20work&context=
true"
```
Context: "Ishaan Works at Microsoft"
Prompt: where does Ishaan work
Prompt with context: Ishaan Works at Microsoft where does Ishaan work
Response: {"response":"?\nhttps://www.youtube.com/watch?v=lZ4RsYJyh5g\nIshaan works at Microsoft. Who is Ishaan?\nNo, Ishaan works at Microsoft.\nWho is Ishaan?\nIshaan works at Microsoft."}


Additionally if a user wants to clear the context they can send 

```
k exec -it demo -- curl -X POST -H "Content-Type: application/json" -d '{"context":"clear"}' http://127.0.0.1:5000/configure
```
And then context is cleared. 


In the case we have a very long context that goes over our input token limit, we truncate the beginning of the prompt in a sliding window fashion such that we never go over the the maximum allowable amount of input. 
