### PR TITLE
feat: Add Readiness Script

### DIFF
--- a/llama-2-chat/Dockerfile
+++ b/llama-2-chat/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /workspace/llama
 RUN pip install -e .
 RUN pip install flask
 
-COPY ../llama-readiness-check.sh /workspace/
-RUN chmod +x /workspace/llama-readiness-check.sh
+COPY ../llama-readiness-check.sh .
+RUN chmod +x llama-readiness-check.sh
 
 ADD code /workspace/llama/llama-2-chat

--- a/llama-2-chat/Dockerfile
+++ b/llama-2-chat/Dockerfile
@@ -8,4 +8,7 @@ WORKDIR /workspace/llama
 RUN pip install -e .
 RUN pip install flask
 
+COPY ../llama-readiness-check.sh /workspace/
+RUN chmod +x /workspace/llama-readiness-check.sh
+
 ADD code /workspace/llama/llama-2-chat

--- a/llama-2/Dockerfile
+++ b/llama-2/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /workspace/llama
 RUN pip install -e .
 RUN pip install flask
 
-COPY ../llama-readiness-check.sh /workspace/
-RUN chmod +x /workspace/llama-readiness-check.sh
+COPY ../llama-readiness-check.sh .
+RUN chmod +x llama-readiness-check.sh
 
 ADD code /workspace/llama/llama-2

--- a/llama-2/Dockerfile
+++ b/llama-2/Dockerfile
@@ -8,4 +8,7 @@ WORKDIR /workspace/llama
 RUN pip install -e .
 RUN pip install flask
 
+COPY ../llama-readiness-check.sh /workspace/
+RUN chmod +x /workspace/llama-readiness-check.sh
+
 ADD code /workspace/llama/llama-2

--- a/llama-readiness-check.sh
+++ b/llama-readiness-check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Extract the ordinal from the pod's hostname
+ordinal=$(hostname | grep -o '[^-]*$')
+
+# Common check: Count the number of web_example_chat_completion.py processes
+web_example_count=$(pgrep -af "python -u web_example_chat_completion.py" | wc -l)
+
+# Get PID of torchrun process
+torchrun_pid=$(pgrep -f "torchrun")
+
+# Check if torchrun exists and get nproc_per_node value
+if [[ -n "$torchrun_pid" ]]; then
+    nproc_per_node_value=$(cat /proc/$torchrun_pid/cmdline | tr '\0' ' ' | awk -F"--nproc_per_node=" '{print $2}' | awk '{print $1}')
+else
+    exit 1  # readiness probe fails if torchrun doesn't exist
+fi
+
+# Check conditions for all pods
+if [[ $web_example_count -ne $nproc_per_node_value ]]; then
+    exit 1  # readiness probe fails if count doesn't match nproc_per_node
+fi
+
+# Additional check for pod 0
+if [[ $ordinal -eq 0 ]]; then
+    if ! curl -s http://localhost:5000/healthz | grep -q "Healthy"; then
+        exit 1  # readiness probe fails if pod 0 health check doesn't pass
+    fi
+fi
+
+exit 0  # readiness probe success


### PR DESCRIPTION
Because sts pod 0 has different behavior than other pods. We need custom readiness probe logic here to make sure master and workers are performing their roles.  