### PR TITLE
feat: Use FastAPI implementation, introduce worker server and health check

### DIFF
--- a/llama-2-chat/Dockerfile
+++ b/llama-2-chat/Dockerfile
@@ -6,6 +6,7 @@ RUN git clone https://github.com/facebookresearch/llama
 WORKDIR /workspace/llama
 
 RUN pip install -e .
-RUN pip install flask
+RUN pip install fastapi pydantic
+RUN pip install 'uvicorn[standard]'
 
 ADD code /workspace/llama/llama-2-chat

--- a/llama-2-chat/code/web_example_chat_completion.py
+++ b/llama-2-chat/code/web_example_chat_completion.py
@@ -23,9 +23,6 @@ args = parser.parse_args()
 
 should_shutdown = False
 
-app_main = FastAPI()  # For the main process
-app_worker = FastAPI()  # For the worker processes
-
 def build_generator(params):
     """Build Llama generator from provided parameters."""
     return Llama.build(**params)
@@ -57,94 +54,101 @@ gen_params = {
 
 generator = build_generator(gen_params)
 
-@app_main.get('/')
-def home():
-    return "Server is running", 200
+def setup_main_routes(): 
+    @app_main.get('/')
+    def home():
+        return "Server is running", 200
 
-@app_main.get("/healthz")
-@app_worker.get("/healthz")
-def health_check():
-    if not torch.cuda.is_available():
-        raise HTTPException(status_code=500, detail="No GPU available")
-    if not generator:
-        raise HTTPException(status_code=500, detail="Llama model not initialized")
-    return {"status": "Healthy"}
+    @app_main.get("/healthz")
+    def health_check():
+        if not torch.cuda.is_available():
+            raise HTTPException(status_code=500, detail="No GPU available")
+        if not generator:
+            raise HTTPException(status_code=500, detail="Llama model not initialized")
+        return {"status": "Healthy"}
 
-@app_main.post("/shutdown")
-def shutdown():
-    """Shutdown the server and worker processes."""
-    global should_shutdown
-    should_shutdown = True
-    if dist.get_world_size() > 1:
-        broadcast_for_shutdown()
-    shutdown_server()
-    return {}
+    @app_main.post("/shutdown")
+    def shutdown():
+        """Shutdown the server and worker processes."""
+        global should_shutdown
+        should_shutdown = True
+        if dist.get_world_size() > 1:
+            broadcast_for_shutdown()
+        shutdown_server()
+        return {}
 
-class ChatParameters(BaseModel):
-    input_data: dict
-    parameters: Optional[dict] = None
+    class ChatParameters(BaseModel):
+        input_data: dict
+        parameters: Optional[dict] = None
 
-@app_main.post("/chat")
-def chat_completion(params: ChatParameters):
-    input_data = params.input_data
-    if not input_data:
-        raise HTTPException(status_code=400, detail="Input data is required")
-    
-    input_string = input_data.get("input_string")
-    if not input_string:
-        raise HTTPException(status_code=400, detail="Input string is required")
+    @app_main.post("/chat")
+    def chat_completion(params: ChatParameters):
+        input_data = params.input_data
+        if not input_data:
+            raise HTTPException(status_code=400, detail="Input data is required")
+        
+        input_string = input_data.get("input_string")
+        if not input_string:
+            raise HTTPException(status_code=400, detail="Input string is required")
 
-    parameters = params.parameters if params.parameters else {}
-    max_gen_len = parameters.get('max_gen_len', None)
-    temperature = parameters.get('temperature', 0.6)
-    top_p = parameters.get('top_p', 0.9)
+        parameters = params.parameters if params.parameters else {}
+        max_gen_len = parameters.get('max_gen_len', None)
+        temperature = parameters.get('temperature', 0.6)
+        top_p = parameters.get('top_p', 0.9)
 
-    if dist.get_world_size() > 1:
-        # Broadcast generation params to worker processes
-        broadcast_for_generation(input_string, max_gen_len, temperature, top_p)
+        if dist.get_world_size() > 1:
+            # Broadcast generation params to worker processes
+            broadcast_for_generation(input_string, max_gen_len, temperature, top_p)
 
-    # Master's own generation
-    try:
-        results = generator.chat_completion(
-            input_string,
-            max_gen_len=max_gen_len,
-            temperature=temperature,
-            top_p=top_p,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=400, detail="Request Failed: " + str(e))
+        # Master's own generation
+        try:
+            results = generator.chat_completion(
+                input_string,
+                max_gen_len=max_gen_len,
+                temperature=temperature,
+                top_p=top_p,
+            )
+        except Exception as e:
+            raise HTTPException(status_code=400, detail="Request Failed: " + str(e))
 
-    if len(results) == 0:
-        raise HTTPException(status_code=404, detail="No results")
-    
-    response_data = []
-    for dialog, result in zip(input_string, results):
-        conversation = []
-        for msg in dialog:
-            print(f"{msg['role'].capitalize()}: {msg['content']}\n")
+        if len(results) == 0:
+            raise HTTPException(status_code=404, detail="No results")
+        
+        response_data = []
+        for dialog, result in zip(input_string, results):
+            conversation = []
+            for msg in dialog:
+                print(f"{msg['role'].capitalize()}: {msg['content']}\n")
+                conversation.append({
+                    "role": msg['role'].capitalize(),
+                    "content": msg['content']
+                })
+            print(
+                f"> {result['generation']['role'].capitalize()}: {result['generation']['content']}"
+            )
             conversation.append({
-                "role": msg['role'].capitalize(),
-                "content": msg['content']
+                "role": result['generation']['role'].capitalize(),
+                "content": result['generation']['content']
             })
-        print(
-            f"> {result['generation']['role'].capitalize()}: {result['generation']['content']}"
-        )
-        conversation.append({
-            "role": result['generation']['role'].capitalize(),
-            "content": result['generation']['content']
-        })
-        response_data.append(conversation)
-        print("\n==================================\n")
+            response_data.append(conversation)
+            print("\n==================================\n")
 
-    return {"results": response_data}
+        return {"results": response_data}
+
+def setup_worker_routes():
+    @app_worker.get("/healthz")
+    def health_check():
+        if not torch.cuda.is_available():
+            raise HTTPException(status_code=500, detail="No GPU available")
+        if not generator:
+            raise HTTPException(status_code=500, detail="Llama model not initialized")
+        return {"status": "Healthy"}
 
 def start_worker_server():
     uvicorn.run(app=app_worker, host='0.0.0.0', port=5000)
     print(f"Worker {dist.get_rank()} HTTP health server started at port 5000")
 
 def worker_listen_tasks(): 
-    # Note to enable logs to std out uncomment 
-    # sys.stdout = sys.__stdout__
     while True:
         worker_num = dist.get_rank()
         print(f"Worker {worker_num} ready to recieve next command")
@@ -171,15 +175,35 @@ def worker_listen_tasks():
 
 
 if __name__ == "__main__":
-    local_rank = int(os.environ.get("LOCAL_RANK"))
+    # Fetch the LOCAL_RANK environment variable to determine the rank of this process
+    # on the current node (machine).
+    local_rank = int(os.environ.get("LOCAL_RANK")) 
+
+    # dist.get_rank() provides the global rank across all nodes. 
+    # The following code is run by the globally ranked process 0.
     if dist.get_rank() == 0:
-        # Start the main server
+        # This is the main server that handles the main logic of our application.
+        app_main = FastAPI()
+        setup_main_routes()
         uvicorn.run(app=app_main, host='0.0.0.0', port=5000)  # Use the app_main instance
     else:
-        if local_rank == 0: 
-            # Start the worker server in a separate thread
+        # This code is executed by all processes that aren't the globally ranked 0.
+        # This includes processes on the main node as well as on other nodes.
+
+        # Uncomment to enable worker logs
+        # sys.stdout = sys.__stdout__
+
+        # If the current process is the locally ranked 0 (i.e., the primary process)
+        # on its node, then it starts a worker server that exposes a health check endpoint.
+        if local_rank == 0:
+            app_worker = FastAPI()
+            setup_worker_routes()
+             
+            # Start the worker server in a separate thread. This worker server will
+            # provide a healthz endpoint for monitoring the health of the node.
             server_thread = threading.Thread(target=start_worker_server, daemon=True)
             server_thread.start()
 
-        # Listen for tasks in the main thread
+        # Regardless of local rank, all non-globally-0-ranked processes will listen
+        # for tasks (like chat completion) from the main server.
         worker_listen_tasks()

--- a/llama-2/Dockerfile
+++ b/llama-2/Dockerfile
@@ -6,6 +6,7 @@ RUN git clone https://github.com/facebookresearch/llama
 WORKDIR /workspace/llama
 
 RUN pip install -e .
-RUN pip install flask
+RUN pip install fastapi pydantic
+RUN pip install 'uvicorn[standard]'
 
 ADD code /workspace/llama/llama-2

--- a/llama-2/code/web_example_text_completion.py
+++ b/llama-2/code/web_example_text_completion.py
@@ -1,5 +1,10 @@
-from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi import FastAPI, HTTPException
+import uvicorn
 from pydantic import BaseModel
+from typing import Optional
+import threading
+import time
+from multiprocessing import Value
 
 from llama import Llama
 import torch
@@ -18,9 +23,13 @@ parser.add_argument("--max_batch_size", type=int, default=4, help="Maximum batch
 parser.add_argument("--model_parallel_size", type=int, default=int(os.environ.get("WORLD_SIZE", 1)), help="Model parallel size.")
 args = parser.parse_args()
 
+HEALTH_CHECK = 20 # seconds, adjust as needed
+TIMEOUT = HEALTH_CHECK * 2  # seconds, adjust as needed
+
 should_shutdown = False
 
-app = FastAPI()
+app_main = FastAPI()  # For the main process
+app_worker = FastAPI()  # For the worker processes
 
 def build_generator(params):
     """Build Llama generator from provided parameters."""
@@ -42,6 +51,15 @@ def shutdown_server():
     """Shut down the server."""
     os.kill(os.getpid(), signal.SIGINT)
 
+def update_process_health_status(local_rank):
+    """
+    This function will be run by each worker to periodically update its health status timestamp.
+    """
+    while True:
+        # Update with the current time.
+        process_health_statuses[local_rank].value = time.time() 
+        time.sleep(HEALTH_CHECK)
+
 # Default values for the generator
 gen_params = {
     'ckpt_dir': args.ckpt_dir,
@@ -52,27 +70,28 @@ gen_params = {
 }
 
 generator = build_generator(gen_params)
+# Needs to be created after model initialization  (build_generator)
+process_health_statuses = [Value('d', time.time()) for _ in range(int(os.environ.get("LOCAL_WORLD_SIZE", 1)))]
 
-@app.get('/')
-async def home():
+@app_main.get('/')
+def home():
     return "Server is running", 200
 
-@app.get("/healthz")
+@app_main.get("/healthz")
+@app_worker.get("/healthz")
 def health_check():
+    current_time = time.time()
+    unhealthy_processes = [i for i, timestamp in enumerate(process_health_statuses) if current_time - timestamp.value > TIMEOUT]
+    
     if not torch.cuda.is_available():
         raise HTTPException(status_code=500, detail="No GPU available")
     if not generator:
         raise HTTPException(status_code=500, detail="Llama model not initialized")
+    if unhealthy_processes:
+        raise HTTPException(status_code=500, detail=f"Processes {unhealthy_processes} are unhealthy")
     return {"status": "Healthy"}
 
-# @app.teardown_request
-# def check_shutdown(exception=None):
-#     global should_shutdown
-#     if should_shutdown:
-#         print("Server shutting down...")
-#         shutdown_server()
-
-@app.post("/shutdown")
+@app_main.post("/shutdown")
 def shutdown():
     if dist.get_world_size() > 1:
         broadcast_for_shutdown()
@@ -81,9 +100,9 @@ def shutdown():
 
 class GenerationParameters(BaseModel):
     prompts: list
-    parameters: dict = None
+    parameters: Optional[dict] = None
 
-@app.post("/generate")
+@app_main.post("/generate")
 def generate_text(params: GenerationParameters):
     prompts = params.prompts
     # Check if the prompts are provided
@@ -124,30 +143,49 @@ def generate_text(params: GenerationParameters):
 
     return {"results": response_data}
 
-if __name__ == "__main__":
-    if dist.get_rank() == 0:
-        app.run(host='0.0.0.0', port=5000)
-    else:
-        while True:
-            worker_num = dist.get_rank()
-            print(f"Worker {worker_num} ready to receive next command")
-            config = [None] * 3
-            dist.broadcast_object_list(config, src=0)
-            command = config[0]
+def start_worker_server():
+    uvicorn.run(app=app_worker, host='0.0.0.0', port=5000)
+    print(f"Worker {dist.get_rank()} HTTP health server started at port 5000")
 
-            if command == "text_generate":
-                try:
-                    prompts = config[1]
-                    parameters = config[2]
-                    generator.text_completion(
-                        prompts,
-                        max_gen_len=parameters.get('max_gen_len', None),
-                        temperature=parameters.get('temperature', 0.6),
-                        top_p=parameters.get('top_p', 0.9)
-                    )
-                    print(f"Worker {worker_num} completed generation")              
-                except Exception as e:
-                    print(f"Error in generation: {str(e)}")
-            elif command == "shutdown":
-                print(f"Worker {worker_num} shutting down")
-                sys.exit(0)
+def worker_listen_tasks():
+    while True:
+        worker_num = dist.get_rank()
+        print(f"Worker {worker_num} ready to receive next command")
+        config = [None] * 3
+        dist.broadcast_object_list(config, src=0)
+        command = config[0]
+
+        if command == "text_generate":
+            try:
+                prompts = config[1]
+                parameters = config[2]
+                generator.text_completion(
+                    prompts,
+                    max_gen_len=parameters.get('max_gen_len', None),
+                    temperature=parameters.get('temperature', 0.6),
+                    top_p=parameters.get('top_p', 0.9)
+                )
+                print(f"Worker {worker_num} completed generation")              
+            except Exception as e:
+                print(f"Error in generation: {str(e)}")
+        elif command == "shutdown":
+            print(f"Worker {worker_num} shutting down")
+            sys.exit(0)
+
+if __name__ == "__main__":
+    local_rank = int(os.environ.get("LOCAL_RANK"))
+    # Start the periodic health update in a separate thread
+    health_update_thread = threading.Thread(target=update_process_health_status, args=(local_rank,), daemon=True)
+    health_update_thread.start()
+    
+    if dist.get_rank() == 0:
+        # Start the main server
+        uvicorn.run(app=app_main, host='0.0.0.0', port=5000)  # Use the app_main instance
+    else:
+        if local_rank == 0: 
+            # Start the worker server in a separate thread
+            server_thread = threading.Thread(target=start_worker_server, daemon=True)
+            server_thread.start()
+
+        # Listen for tasks in the main thread
+        worker_listen_tasks()

--- a/llama-2/code/web_example_text_completion.py
+++ b/llama-2/code/web_example_text_completion.py
@@ -23,6 +23,7 @@ parser.add_argument("--max_batch_size", type=int, default=4, help="Maximum batch
 parser.add_argument("--model_parallel_size", type=int, default=int(os.environ.get("WORLD_SIZE", 1)), help="Model parallel size.")
 args = parser.parse_args()
 
+process_health_statuses = [Value('d', time.time()) for _ in range(int(os.environ.get("LOCAL_WORLD_SIZE", 1)))]
 HEALTH_CHECK = 20 # seconds, adjust as needed
 TIMEOUT = HEALTH_CHECK * 2  # seconds, adjust as needed
 
@@ -70,8 +71,6 @@ gen_params = {
 }
 
 generator = build_generator(gen_params)
-# Needs to be created after model initialization  (build_generator)
-process_health_statuses = [Value('d', time.time()) for _ in range(int(os.environ.get("LOCAL_WORLD_SIZE", 1)))]
 
 @app_main.get('/')
 def home():


### PR DESCRIPTION
FastAPI has lot of advantages over flask, namely performance, typechecking, automated api docs, async support and support for modern python features. This PR makes use of FastAPI over Flask. 

Readiness probe runs on every pod of the statefulset. Each pod is on its own node. The readiness probe works by probing endpoint /healthz,  port 5000.

Each pod might be running several processes. We are using torchrun commands here. So for example if we have a command like this: 
torchrun --nproc_per_node=4 --nnodes=2 --node_rank=0 --master_addr="192.168.0.1" --master_port=1234 web_example.py

We have two nodes each running four processes. Node 1 will run processes #0-3 and Node 2 processes #4-7. Readiness probe will fail on node/pod #2 because all its processes are workers no server will get spun up. So we get a locally unique local rank to ensure one endpoint is exposed on each pod. So with this PR, global process rank #4 will spin up a server as well.

